### PR TITLE
Fix app loading (v0.1.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-tt-newsapps",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Scaffold out a Texas Tribune web app or graphic.",
   "license": "MIT",
   "repository": "texastribune/generator-tt-newsapps",


### PR DESCRIPTION
`graphics` became `graphic`, and now `map` exists, but the npm module doesn't know that. The `package.json` needs to be told to pull them over when installed via `npm`.
